### PR TITLE
feat: add @supabase/auth-helpers-nextjs package with deprecation notice

### DIFF
--- a/source_code/package-lock.json
+++ b/source_code/package-lock.json
@@ -2335,6 +2335,20 @@
         "@sinonjs/commons": "^3.0.1"
       }
     },
+    "node_modules/@supabase/auth-helpers-nextjs": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-helpers-nextjs/-/auth-helpers-nextjs-0.10.0.tgz",
+      "integrity": "sha512-2dfOGsM4yZt0oS4TPiE7bD4vf7EVz7NRz/IJrV6vLg0GP7sMUx8wndv2euLGq4BjN9lUCpu6DG/uCC8j+ylwPg==",
+      "deprecated": "This package is now deprecated - please use the @supabase/ssr package instead.",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-helpers-shared": "0.7.0",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "peerDependencies": {
+        "@supabase/supabase-js": "^2.39.8"
+      }
+    },
     "node_modules/@supabase/auth-helpers-react": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/@supabase/auth-helpers-react/-/auth-helpers-react-0.5.0.tgz",


### PR DESCRIPTION
Added a dependency that was missing that did not allow the project to run.