### PR TITLE
Connecting to hosted backend Openrouter API

### DIFF
--- a/source_code/Dockerfile
+++ b/source_code/Dockerfile
@@ -19,4 +19,3 @@ EXPOSE 3000
 # Start dev server
 CMD ["npm", "run", "dev"]
 
- 

--- a/source_code/docker-compose.yml
+++ b/source_code/docker-compose.yml
@@ -5,4 +5,3 @@ services:
     build: .
     ports:
       - "3000:3000"
-

--- a/source_code/package-lock.json
+++ b/source_code/package-lock.json
@@ -23,6 +23,7 @@
         "lucide-react": "^0.546.0",
         "next": "15.5.3",
         "next-themes": "^0.4.6",
+        "node-fetch": "^3.3.2",
         "react": "19.1.0",
         "react-dom": "19.1.0",
         "react-dropzone": "^14.3.8",

--- a/source_code/package.json
+++ b/source_code/package.json
@@ -27,6 +27,7 @@
     "lucide-react": "^0.546.0",
     "next": "15.5.3",
     "next-themes": "^0.4.6",
+    "node-fetch": "^3.3.2",
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "react-dropzone": "^14.3.8",


### PR DESCRIPTION
This pull request succesfully hosts a translated Python version of the openrouter logic for the chatbot on PythonAnywhere. API keys and URL are set securely as env variables on PythonAnywhere. Typescript code inside hand me down project fetches from this hosted openrouter API and starts a chat inside the terminal for testing purposes where dev can chat with model back and forth. To start, go to cd source_code/app/chatbot and run npx ts-node openrouter_logic.ts